### PR TITLE
Signal a special condition for unknown commands

### DIFF
--- a/README
+++ b/README
@@ -105,6 +105,10 @@ Parse the list of command-line arguments, input into commands and call
 them.  Returns {{#t}} on successful completion of calling commands, {{#f}}
 if parsing was aborted.
 
+This procedure may signal an {{unknown-command}} condition when a
+command was given on the command-line which isn't defined in any of
+the command groups.
+
 <parameter>groups</parameter>
 
 The groups parameter holds the list of command-groups that {{parse}} draws

--- a/imperative-command-line-a.scm
+++ b/imperative-command-line-a.scm
@@ -138,6 +138,10 @@
 (define (abort-parse)
   (signal (make-property-condition 'abort-parse)))
 
+(define (unknown-command name)
+  (let ((msg (sprintf "unexpected symbol ~S~%" name)))
+    (make-property-condition 'unknown-command 'name name 'message msg)))
+
 (define (%parse input)
   (let* ((callinfos (map (lambda (x) (list)) (groups))))
     (let loop ((input input)
@@ -156,7 +160,7 @@
                                def)
                              (groups))))
           (unless def
-            (error (sprintf "unexpected symbol ~S~%" opsym)))
+            (signal (unknown-command opsym)))
           (let ((narg (length (command-args def))))
             (when (< count narg)
               (error (sprintf "~A requires ~A arguments, but only ~A were given"


### PR DESCRIPTION
To help applications using this library to handle the quite possible and
common scenario of running into an unknown command name, signal a
specific condition which can easily be handled separately. This prevents
applications from having to handle and inspect all exceptions just to
gracefully exit after this situation occurs.

This is the first of my hopefully helpful pull requests/issues.

This breaks my pull request retroj/mowedline#12, but adding this would allow us to fix retroj/mowedline#9 without catching all exceptions that happen ever.

I thought calling `(signal (unknown-command ...))` looked clearer than just calling `unknown-command` and having it signal the condition. Contrary to `abort-parse`, which I think is better the way it is (just as a comparison).

I updated the readme because I think this change is relevant to anyone using the library, but I don't know much about the chicken wiki's markup syntax, so I hope the `{{...}}` is correct there.

Please let me know what you think. I know some people are averse to introducing new conditions/exceptions, but I don't see any other way to handle this cleanly at the moment.
